### PR TITLE
Marshal metric Set

### DIFF
--- a/data/metric/metrics.go
+++ b/data/metric/metrics.go
@@ -21,6 +21,7 @@ type Attribute struct {
 	Value string
 }
 
+// If any more SourceTypes are added update parseSourceType in infra-integrations-sdk/data/metric/set_marshal.go
 const (
 	// GAUGE is a value that may increase and decrease. It is stored as-is.
 	GAUGE SourceType = iota

--- a/data/metric/set_marshal.go
+++ b/data/metric/set_marshal.go
@@ -70,6 +70,8 @@ func marshalValue(f reflect.StructField, v reflect.Value, ms *Set) error {
 	case reflect.Struct:
 		return marshalStruct(v.Type(), v, ms)
 	case reflect.Ptr:
+		// If the pointer is nil we don't process it
+		// regardless of if it had the correct struct field tags
 		if v.IsNil() {
 			return nil
 		}
@@ -96,7 +98,7 @@ func marshalStruct(t reflect.Type, v reflect.Value, ms *Set) error {
 // marshalField marshals a struct field into a metric if both metric tags
 // are present.
 func marshalField(f reflect.StructField, v reflect.Value, ms *Set) error {
-	// Get struct tag values
+	// Get struct field tag values
 	metricName, hasMetricName := f.Tag.Lookup(metricNameTag)
 	sourceTypeString, hasSourceType := f.Tag.Lookup(sourceTypeTag)
 

--- a/data/metric/set_marshal.go
+++ b/data/metric/set_marshal.go
@@ -17,14 +17,13 @@ const (
 )
 
 func (ms *Set) MarshalMetrics(data interface{}) error {
-	t := reflect.TypeOf(data)
 	r := reflect.ValueOf(data)
 	value := reflect.Indirect(r)
 
 	if value.Kind() != reflect.Struct {
 		return errors.New("metric: can only directly unmarshal structs")
 	}
-	return marshalStruct(t, value, ms)
+	return marshalStruct(value.Type(), value, ms)
 }
 
 // marshalValue takes in a struct field and does a kind switch on it to determine further
@@ -35,7 +34,7 @@ func marshalValue(f reflect.StructField, v reflect.Value, ms *Set) error {
 		return marshalStruct(v.Type(), v, ms)
 	case reflect.Ptr:
 		if v.IsNil() {
-			return fmt.Errorf("metric: Marshal(nil %s)", f.Type.String())
+			return nil
 		}
 
 		return marshalValue(f, v.Elem(), ms)

--- a/data/metric/set_marshal.go
+++ b/data/metric/set_marshal.go
@@ -1,0 +1,100 @@
+package metric
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+const (
+	// metricNameTag is the struct tag for specifying a metric name on a struct
+	metricNameTag = "metric_name"
+
+	// sourceTypeTag is the struct tag for specifying the SourceType of a metric.
+	// Tag is case insensitive and should match the type names.
+	sourceTypeTag = "source_type"
+)
+
+func (ms *Set) MarshalMetrics(data interface{}) error {
+	t := reflect.TypeOf(data)
+	r := reflect.ValueOf(data)
+	value := reflect.Indirect(r)
+
+	if value.Kind() != reflect.Struct {
+		return errors.New("metric: can only directly unmarshal structs")
+	}
+	return marshalStruct(t, value, ms)
+}
+
+// marshalValue takes in a struct field and does a kind switch on it to determine further
+// marshaling.
+func marshalValue(f reflect.StructField, v reflect.Value, ms *Set) error {
+	switch v.Kind() {
+	case reflect.Struct:
+		return marshalStruct(v.Type(), v, ms)
+	case reflect.Ptr:
+		if v.IsNil() {
+			return fmt.Errorf("metric: Marshal(nil %s)", f.Type.String())
+		}
+
+		return marshalValue(f, v.Elem(), ms)
+	default:
+		return marshalField(f, v, ms)
+	}
+}
+
+// marshalStruct marshals a struct into it's separate fields
+func marshalStruct(t reflect.Type, v reflect.Value, ms *Set) error {
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		fv := v.FieldByName(f.Name)
+		if err := marshalValue(f, fv, ms); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// marshalField marshals a struct field into a metric if both metric tags
+// are present.
+func marshalField(f reflect.StructField, v reflect.Value, ms *Set) error {
+	// Get struct tag values
+	metricName, hasMetricName := f.Tag.Lookup(metricNameTag)
+	sourceTypeString, hasSourceType := f.Tag.Lookup(sourceTypeTag)
+
+	// Validate that we have all the needed tag information to process the metric
+	if !hasMetricName && !hasSourceType {
+		return nil
+	} else if hasMetricName != hasSourceType {
+		return fmt.Errorf("metric: Field '%s' must have both %s and %s struct tags", f.Name, metricNameTag, sourceTypeTag)
+	}
+
+	// Convert source_type tag to a value
+	sourceType, err := parseSourceType(sourceTypeString)
+	if err != nil {
+		return err
+	}
+
+	// Sets the metric, passing a good deal of additional error handling onto this function as
+	// it already handles type checking per sourceType.
+	return ms.SetMetric(metricName, v.Interface(), sourceType)
+}
+
+// parseSourceType does a case insensitive conversion from a string
+// to a SourceType. An error will be returned if no valid SourceType matched.
+func parseSourceType(sourceTypeTag string) (SourceType, error) {
+	switch strings.ToLower(sourceTypeTag) {
+	case "attribute":
+		return ATTRIBUTE, nil
+	case "rate":
+		return RATE, nil
+	case "delta":
+		return DELTA, nil
+	case "gauge":
+		return GAUGE, nil
+	default:
+		return 0, fmt.Errorf("metric: Unknown source_type %s", sourceTypeTag)
+	}
+}

--- a/data/metric/set_marshal.go
+++ b/data/metric/set_marshal.go
@@ -28,7 +28,7 @@ const (
 //
 // Needed struct field tags are "metric_name" and "source_type". The value of
 // "metric_name" will be the name argument to SetMetric. The value
-// of "source_type" the is case insensitively matched against values below to a SourceType
+// of "source_type" is case insensitively matched against values below to a SourceType
 // and passed as the sourceType argument to SetMetric.
 // If the value does not match one of the values below an error will be returned.
 //   - gauge
@@ -41,10 +41,10 @@ const (
 //
 // Examples of struct field tags:
 //   type Data struct {
-//   	Gauge     int     `metric_name:"metric.gauge" source_type:"Gauge"`
-//   	Attribute string  `metric_name:"metric.attribute" source_type:"attribute"`
-//   	Rate      float64 `metric_name:"metric.rate" source_type:"RATE"`
-//    	Delta     float64 `metric_name:"metric.delta" source_type:"delta"`
+//      Gauge     int     `metric_name:"metric.gauge" source_type:"Gauge"`
+//      Attribute string  `metric_name:"metric.attribute" source_type:"attribute"`
+//      Rate      float64 `metric_name:"metric.rate" source_type:"RATE"`
+//      Delta     float64 `metric_name:"metric.delta" source_type:"delta"`
 //   }
 //
 // Any non-struct/non-pointer value that has the correct struct field tags
@@ -69,6 +69,8 @@ func marshalValue(f reflect.StructField, v reflect.Value, ms *Set) error {
 	switch v.Kind() {
 	case reflect.Struct:
 		return marshalStruct(v.Type(), v, ms)
+	case reflect.Interface:
+		fallthrough
 	case reflect.Ptr:
 		// If the pointer is nil we don't process it
 		// regardless of if it had the correct struct field tags

--- a/data/metric/set_marshal_test.go
+++ b/data/metric/set_marshal_test.go
@@ -40,11 +40,16 @@ func TestSet_MarshalMetricsComplexStruct(t *testing.T) {
 		Map   map[string]bool
 	}
 
+	type InterfaceStruct struct {
+		Metric int `metric_name:"metric.interface" source_type:"gauge"`
+	}
+
 	complexStruct := &struct {
-		Gauge     int    `metric_name:"metric.gauge" source_type:"gauge"`
-		Attribute string `metric_name:"metric.attribute" source_type:"attribute"`
-		Nested    *NestedStruct
-		Slice     []string
+		Gauge           int    `metric_name:"metric.gauge" source_type:"gauge"`
+		Attribute       string `metric_name:"metric.attribute" source_type:"attribute"`
+		Nested          *NestedStruct
+		Slice           []string
+		NestedInterface interface{}
 	}{
 		10,
 		"some-attribute",
@@ -54,6 +59,9 @@ func TestSet_MarshalMetricsComplexStruct(t *testing.T) {
 			map[string]bool{"one": true},
 		},
 		[]string{"one", "two", "three"},
+		&InterfaceStruct{
+			40,
+		},
 	}
 
 	err := ms.MarshalMetrics(complexStruct)
@@ -62,6 +70,7 @@ func TestSet_MarshalMetricsComplexStruct(t *testing.T) {
 	assert.Equal(t, float64(10), ms.Metrics["metric.gauge"])
 	assert.Equal(t, complexStruct.Attribute, ms.Metrics["metric.attribute"])
 	assert.Equal(t, float64(0), ms.Metrics["metric.delta"])
+	assert.Equal(t, float64(40), ms.Metrics["metric.interface"])
 }
 
 func TestSet_MarshalMetricsNonStruct(t *testing.T) {

--- a/data/metric/set_marshal_test.go
+++ b/data/metric/set_marshal_test.go
@@ -1,0 +1,117 @@
+package metric
+
+import (
+	"testing"
+
+	"github.com/newrelic/infra-integrations-sdk/persist"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSet_MarshalMetricsSimpleStruct(t *testing.T) {
+	ms := NewSet("some-event-type", persist.NewInMemoryStore(), Attr("k", "v"))
+
+	simpleStruct := struct {
+		Gauge     int     `metric_name:"metric.gauge" source_type:"gauge"`
+		Attribute string  `metric_name:"metric.attribute" source_type:"attribute"`
+		Rate      float64 `metric_name:"metric.rate" source_type:"rate"`
+		Delta     float64 `metric_name:"metric.delta" source_type:"delta"`
+	}{
+		10,
+		"some-attribute",
+		float64(20),
+		float64(30),
+	}
+
+	err := ms.MarshalMetrics(simpleStruct)
+	assert.NoError(t, err, "marshal error")
+
+	assert.Equal(t, float64(10), ms.Metrics["metric.gauge"])
+	assert.Equal(t, simpleStruct.Attribute, ms.Metrics["metric.attribute"])
+	assert.Equal(t, float64(0), ms.Metrics["metric.rate"])
+	assert.Equal(t, float64(0), ms.Metrics["metric.delta"])
+}
+
+func TestSet_MarshalMetricsComplexStruct(t *testing.T) {
+	ms := NewSet("some-event-type", persist.NewInMemoryStore(), Attr("k", "v"))
+
+	type NestedStruct struct {
+		Rate  *float64 `metric_name:"metric.rate" source_type:"rate"`
+		Delta float64  `metric_name:"metric.delta" source_type:"delta"`
+		Map   map[string]bool
+	}
+
+	complexStruct := &struct {
+		Gauge     int    `metric_name:"metric.gauge" source_type:"gauge"`
+		Attribute string `metric_name:"metric.attribute" source_type:"attribute"`
+		Nested    *NestedStruct
+		Slice     []string
+	}{
+		10,
+		"some-attribute",
+		&NestedStruct{
+			nil,
+			float64(10),
+			map[string]bool{"one": true},
+		},
+		[]string{"one", "two", "three"},
+	}
+
+	err := ms.MarshalMetrics(complexStruct)
+	assert.NoError(t, err, "marshal error")
+
+	assert.Equal(t, float64(10), ms.Metrics["metric.gauge"])
+	assert.Equal(t, complexStruct.Attribute, ms.Metrics["metric.attribute"])
+	assert.Equal(t, float64(0), ms.Metrics["metric.delta"])
+}
+
+func TestSet_MarshalMetricsNonStruct(t *testing.T) {
+	ms := NewSet("some-event-type", persist.NewInMemoryStore(), Attr("k", "v"))
+
+	err := ms.MarshalMetrics(1)
+	assert.Error(t, err, "MarshalMetrics must take in a struct or struct pointer")
+}
+
+func TestSet_MarshalMetricsMissingTags(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input interface{}
+		ms    *Set
+	}{
+		{
+			"Missing metric_name",
+			struct {
+				Gauge int `source_type:"gauge"`
+			}{
+				10,
+			},
+			NewSet("some-event-type", persist.NewInMemoryStore(), Attr("k", "v")),
+		},
+		{
+			"Missing source_type",
+			struct {
+				Gauge int `metric_name:"metric.gauge"`
+			}{
+				10,
+			},
+			NewSet("some-event-type", persist.NewInMemoryStore(), Attr("k", "v")),
+		},
+	}
+
+	for _, tc := range testCases {
+		err := tc.ms.MarshalMetrics(tc.input)
+		assert.Error(t, err, "field must have both metric_name and source_type if it wished to be marshaled")
+	}
+}
+
+func TestSet_MarshalMetricsBadSourceType(t *testing.T) {
+	ms := NewSet("some-event-type", persist.NewInMemoryStore(), Attr("k", "v"))
+
+	simpleStruct := struct {
+		Gauge int `metric_name:"metric.gauge" source_type:"nope"`
+	}{
+		10,
+	}
+
+	err := ms.MarshalMetrics(simpleStruct)
+	assert.Error(t, err, "source_type must be a valid value")
+}


### PR DESCRIPTION
#### Description of the changes

Added `MarshalMetrics` to `metric.Set` as a way to utilize struct field tags to turn struct fields into metrics. The way `MarshalMetrics` works is it recursively traverses a struct until a non-struct/non-pointer value is found. If the field associated with that value has the `metric_name` and `source_type` struct field tags it will pass the value into `SetMetric`. Nil pointers are ignored regardless of the required struct field tags being present. 

#### PR Review Checklist
### Author

- [X] add a risk label after carefully considering the "blast radius" of your changes
- [X] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [X] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
